### PR TITLE
Allow chunking members using a flux interface

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,12 +13,10 @@ version = "1.1.0"
 
 repositories {
     jcenter()
-    maven("https://jitpack.io")
 }
 
 dependencies {
-//    compileOnly("net.dv8tion:JDA:4.1.0_97")
-    compileOnly("com.github.dv8fromtheworld:jda:65881bd")
+    compileOnly("net.dv8tion:JDA:4.2.0_168")
 
     api("io.projectreactor:reactor-core:3.2.5.RELEASE")
     implementation(kotlin("stdlib"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "club.minnced"
-version = "1.0.0"
+version = "1.1.0"
 
 repositories {
     jcenter()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
 //    compileOnly("net.dv8tion:JDA:4.1.0_97")
-    compileOnly("com.github.dv8fromtheworld:jda:fbda839")
+    compileOnly("com.github.dv8fromtheworld:jda:0aa3c96")
 
     api("io.projectreactor:reactor-core:3.2.5.RELEASE")
     implementation(kotlin("stdlib"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 
 dependencies {
 //    compileOnly("net.dv8tion:JDA:4.1.0_97")
-    compileOnly("com.github.dv8fromtheworld:jda:0aa3c96")
+    compileOnly("com.github.dv8fromtheworld:jda:65881bd")
 
     api("io.projectreactor:reactor-core:3.2.5.RELEASE")
     implementation(kotlin("stdlib"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,10 +13,12 @@ version = "1.1.0"
 
 repositories {
     jcenter()
+    maven("https://jitpack.io")
 }
 
 dependencies {
-    compileOnly("net.dv8tion:JDA:4.1.0_97")
+//    compileOnly("net.dv8tion:JDA:4.1.0_97")
+    compileOnly("com.github.dv8fromtheworld:jda:fbda839")
 
     api("io.projectreactor:reactor-core:3.2.5.RELEASE")
     implementation(kotlin("stdlib"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("net.dv8tion:JDA:4.0.0_72")
+    compileOnly("net.dv8tion:JDA:4.1.0_97")
 
     api("io.projectreactor:reactor-core:3.2.5.RELEASE")
     implementation(kotlin("stdlib"))

--- a/src/main/kotlin/club/minnced/jda/reactor/attachments.kt
+++ b/src/main/kotlin/club/minnced/jda/reactor/attachments.kt
@@ -73,7 +73,7 @@ fun Message.Attachment.toByteArray(): Mono<ByteArray> {
                        buffer.toByteArray()
                    }
                }
-               .publishOn(Schedulers.elastic())
+               .subscribeOn(Schedulers.elastic())
 }
 
 /**
@@ -107,7 +107,7 @@ fun Message.Attachment.toFile(path: String? = null, file: File? = null): Mono<Fi
             file != null -> downloadToFile(file)
             else -> downloadToFile()
         }
-    }.publishOn(Schedulers.elastic())
+    }.subscribeOn(Schedulers.elastic())
 }
 
 /**

--- a/src/main/kotlin/club/minnced/jda/reactor/chunking.kt
+++ b/src/main/kotlin/club/minnced/jda/reactor/chunking.kt
@@ -19,6 +19,7 @@ package club.minnced.jda.reactor
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import reactor.core.publisher.Flux
+import java.util.function.Consumer
 
 /**
  * Chunk the members of this guild.
@@ -29,9 +30,9 @@ import reactor.core.publisher.Flux
  * @return[Flux] Flux of members
  */
 fun Guild.streamMembers(): Flux<Member> = Flux.create { sink ->
-    val task = loadMembers {
+    val task = loadMembers(Consumer {
         sink.next(it)
-    }
+    })
 
     sink.onCancel(task::cancel)
     task.onError(sink::error)

--- a/src/main/kotlin/club/minnced/jda/reactor/chunking.kt
+++ b/src/main/kotlin/club/minnced/jda/reactor/chunking.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019  Florian Spieß and the contributors of jda-reactor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package club.minnced.jda.reactor
+
+import net.dv8tion.jda.api.entities.Guild
+import net.dv8tion.jda.api.entities.Member
+import net.dv8tion.jda.api.utils.data.DataObject
+import net.dv8tion.jda.internal.entities.GuildImpl
+import net.dv8tion.jda.internal.requests.WebSocketCode
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.publisher.toFlux
+import reactor.core.publisher.toMono
+import java.time.Duration
+import java.util.concurrent.TimeoutException
+
+/**
+ * Chunk the members of this guild.
+ * If guild subscriptions are disabled, this will only work if raw events are enabled.
+ *
+ * **Using this with disabled guild subscriptions is experimental and might break in the future.**
+ *
+ * @param[timeout] Whether the chunking process should timeout automatically
+ *
+ * @return[Flux] Flux of members
+ */
+fun Guild.chunkMembers(timeout: Boolean = true): Flux<Member> {
+    val guild = this as GuildImpl
+
+    if (isLoaded)
+        return memberCache.toFlux()
+    else if (jda.isGuildSubscriptions)
+        return Mono.fromFuture { retrieveMembers() }.flatMapMany { memberCache.toFlux() }
+
+    //FIXME: Make this use the JDA interface instead of internals
+    val request = DataObject.empty()
+            .put("limit", 0)
+            .put("query", "")
+            .put("guild_id", getId())
+
+    val packet = DataObject.empty()
+            .put("op", WebSocketCode.MEMBER_CHUNK_REQUEST)
+            .put("d", request)
+
+    var publisher = jda.client.send(packet.toString()).toMono()
+         .flatMapMany { jda.onRaw("GUILD_MEMBERS_CHUNK") }
+         .map { it.payload }
+         .filter { it.getUnsignedLong("guild_id") == guild.idLong }
+    if (timeout) {
+        publisher = publisher.timeout(Duration.ofSeconds(10))
+                             .onErrorResume(TimeoutException::class.java) { Mono.empty() }
+    }
+    return publisher.takeUntil { it.getArray("members").length() < 1000 }
+                    .flatMapIterable { payload ->
+                        val members = payload.getArray("members")
+                        List(members.length()) { index ->
+                            val json = members.getObject(index)
+                            jda.entityBuilder.createMember(guild, json)
+                        }
+                    }
+}

--- a/src/main/kotlin/club/minnced/jda/reactor/chunking.kt
+++ b/src/main/kotlin/club/minnced/jda/reactor/chunking.kt
@@ -19,20 +19,20 @@ package club.minnced.jda.reactor
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.Member
 import reactor.core.publisher.Flux
-import java.util.function.Consumer
 
 /**
- * Chunk the members of this guild.
- * If guild subscriptions are disabled, this will only work if raw events are enabled.
+ * Load and stream the members of this guild.
  *
- * **Using this with disabled guild subscriptions is experimental and might break in the future.**
+ * This required [GatewayIntent.GUILD_MEMBERS][net.dv8tion.jda.api.requests.GatewayIntent#GUILD_MEMBERS] to be enabled.
+ *
+ * @throws[IllegalStateException] If the GUILD_MEMBERS intent is not enabled
  *
  * @return[Flux] Flux of members
  */
 fun Guild.streamMembers(): Flux<Member> = Flux.create { sink ->
-    val task = loadMembers(Consumer {
+    val task = loadMembers {
         sink.next(it)
-    })
+    }
 
     sink.onCancel(task::cancel)
     task.onError(sink::error)


### PR DESCRIPTION
This makes use of a few JDA internals if guild subscriptions are disabled for the moment.